### PR TITLE
Check tcp listener stats when given an address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [1.0.2] - 2018-12-19
+### Added
+- Add support for unicorn metrics from tcp_listener_stats when given an address (@mattdoller)
+
 ## [1.0.1] - 2017-08-07
 ### Changed
 - Change `sensu-plugin` dependency to `~> 1.2` (@eheydrick)

--- a/bin/metrics-unicorn.rb
+++ b/bin/metrics-unicorn.rb
@@ -55,10 +55,10 @@ class UnicornMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   def stats
     @stats ||= begin
-      if config[:socket]
-        Raindrops::Linux.unix_listener_stats([config[:socket]])[config[:socket]]
-      elsif config[:addr]
+      if config[:addr]
         Raindrops::Linux.tcp_listener_stats([config[:addr]])[config[:addr]]
+      elsif config[:socket]
+        Raindrops::Linux.unix_listener_stats([config[:socket]])[config[:socket]]
       end
     end
   end


### PR DESCRIPTION
We currently only record metrics from the unix listener status, but
the checks script supports both the unix and tcp listeners.  This
updates the metrics check so that if an address is supplied, we'll
check the tcp listener stats.

## Pull Request Checklist

**Is this in reference to an existing issue?**
no

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [x] Existing tests pass 

#### Purpose

- allow unicorn stat gathering through web address, instead of solely through socket file

#### Known Compatibility Issues

